### PR TITLE
Lock bson

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plus.garden.fixtures-mongo",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "mongo fixtures loader for plus.garden",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "Vladimir Polyakov",
   "license": "MIT",
   "dependencies": {
-    "pow-mongodb-fixtures": "0.12.0"
+    "pow-mongodb-fixtures": "0.12.0",
+    "bson": "0.4.23"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@Skadabr had to lock down `bson`. As their latest release has broken the fixture loader. Are you ok to merge this in? I'll create a release and then perhaps you could publish on NPM? 😉 
